### PR TITLE
fix ci workflow warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-            toolchain: ${{ matrix.rust }}
-            override: true
+          toolchain: ${{ matrix.rust }}
       - name: Build the code
         run: cargo build --verbose
       - name: Test the code
@@ -31,9 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Check formatting
         run: cargo fmt --check


### PR DESCRIPTION
This PR uses [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) to setup the Rust toolchain. This fixes the deprecation warnings like:

```

build (ubuntu-latest, beta)
The following actions uses node12 which is deprecated and will be forced to run on node16: actions-rs/toolchain@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```