### PR TITLE
Drop MSRV down to 1.56

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
-        rust: ["beta", "stable"]
+        rust: ["1.56", "beta", "stable"]
 
     runs-on: ${{ matrix.os }}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ impl Display for StrSimError {
             StrSimError::DifferentLengthArgs => "Differing length arguments provided",
         };
 
-        write!(fmt, "{text}")
+        write!(fmt, "{}", text)
     }
 }
 


### PR DESCRIPTION
Currently, [my project](https://github.com/Discord-TTS/Bot) is pulling in a duplicate version of this library as `darling` is pulling `0.10`, my attempt to fix this [was stopped](https://github.com/TedDriggs/darling/pull/280) by the MSRV of 0.11 being raised higher than `darling`, and since this is a literal one line fix (+ CI) I would love if this got pulled in.