### PR TITLE
Use rust-version field of Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ Implementations of string similarity metrics. Includes Hamming, Levenshtein,
 OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and Sørensen-Dice.
 """
 license = "MIT"
+rust-version = "1.56"
 readme = "README.md"
 keywords = ["string", "similarity", "Hamming", "Levenshtein", "Jaro"]
 homepage = "https://github.com/rapidfuzz/strsim-rs"


### PR DESCRIPTION
Followup to #71, this uses the `rust-version` field to help document the MSRV for tools like clippy, crates.io, and others.